### PR TITLE
initial domain model with JavaDoc

### DIFF
--- a/server/src/main/java/rs/ac/fon/gymtracker/domain/Exercise.java
+++ b/server/src/main/java/rs/ac/fon/gymtracker/domain/Exercise.java
@@ -1,0 +1,33 @@
+package rs.ac.fon.gymtracker.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Vežba sa koeficijentom napora (effort) koji utiče na izračun intenziteta treninga.
+ */
+
+@Getter @Setter @NoArgsConstructor
+@Entity @Table(name = "exercise")
+public class Exercise {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Naziv vežbe (npr. "Bench Press"). */
+    @NotBlank @Size(max = 80)
+    private String name;
+
+    /** Kratki opis vežbe (opciono). */
+    @Size(max = 255)
+    private String description;
+
+    /**
+     * Koeficijent napora vežbe (tipično 0.10–5.00).
+     * Koristi se u formuli: intensity = Σ(sets×reps×weight×exercise.effort).
+     */
+    @DecimalMin("0.10") @DecimalMax("5.00")
+    private double effort = 1.0;
+}

--- a/server/src/main/java/rs/ac/fon/gymtracker/domain/Member.java
+++ b/server/src/main/java/rs/ac/fon/gymtracker/domain/Member.java
@@ -1,0 +1,35 @@
+package rs.ac.fon.gymtracker.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Član teretane; opciono može imati izabran paket usluga.
+ */
+
+@Getter @Setter @NoArgsConstructor
+@Entity @Table(name = "member")
+public class Member {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Ime člana. */
+    @NotBlank @Size(max = 60)
+    private String firstName;
+
+    /** Prezime člana. */
+    @NotBlank @Size(max = 60)
+    private String lastName;
+
+    /** Email adresa člana (opciono, validan format). */
+    @Email @Size(max = 120)
+    private String email;
+
+    /** Izabrani paket usluga (FK ka service_package), može biti null. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "package_id")
+    private ServicePackage servicePackage;
+}

--- a/server/src/main/java/rs/ac/fon/gymtracker/domain/ServicePackage.java
+++ b/server/src/main/java/rs/ac/fon/gymtracker/domain/ServicePackage.java
@@ -1,0 +1,35 @@
+package rs.ac.fon.gymtracker.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Paket usluga (npr. Monthly, Quarterly).
+ * Sadrži naziv, opis, trajanje u danima i cenu (u dinarima).
+ */
+
+@Getter @Setter @NoArgsConstructor
+@Entity @Table(name = "service_package")
+public class ServicePackage {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Naziv paketa, obavezno polje (npr. "Monthly"). */
+    @NotBlank @Size(max = 80)
+    private String name;
+
+    /** Kratki opis paketa (opciono). */
+    @Size(max = 255)
+    private String description;
+
+    /** Trajanje paketa u danima (mora biti >= 1). */
+    @Min(1)
+    private int durationDays;
+
+    /** Cena paketa u dinarima (mora biti >= 0). */
+    @Min(0)
+    private int price;
+}

--- a/server/src/main/java/rs/ac/fon/gymtracker/domain/Trainer.java
+++ b/server/src/main/java/rs/ac/fon/gymtracker/domain/Trainer.java
@@ -1,0 +1,39 @@
+package rs.ac.fon.gymtracker.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Trener koji vodi treninge; čuvamo osnovne podatke i korisničko ime.
+ * Lozinka se čuva kao hash (passwordHash).
+ */
+
+@Getter @Setter @NoArgsConstructor
+@Entity @Table(name = "trainer")
+public class Trainer {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Ime trenera. */
+    @NotBlank @Size(max = 60)
+    private String firstName;
+
+    /** Prezime trenera. */
+    @NotBlank @Size(max = 60)
+    private String lastName;
+
+    /** Email adresa (opciono, validan format). */
+    @Email @Size(max = 120)
+    private String email;
+
+    /** Korisničko ime (obavezno, jedinstveno u bazi). */
+    @NotBlank @Size(max = 60)
+    private String username;
+
+    /** Hash lozinke (opciono u ovoj fazi). */
+    @Size(max = 255)
+    private String passwordHash;
+}

--- a/server/src/main/java/rs/ac/fon/gymtracker/domain/TrainingRecord.java
+++ b/server/src/main/java/rs/ac/fon/gymtracker/domain/TrainingRecord.java
@@ -1,0 +1,42 @@
+package rs.ac.fon.gymtracker.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+/**
+ * Jedan odrađen trening: datum, trener, član i izračunati intenzitet (AVL).
+ * Stavke (vežbe/serije/ponavljanja/težine) dodajemo kroz TrainingItem entitet.
+ */
+
+@Getter @Setter @NoArgsConstructor
+@Entity @Table(name = "training_record")
+public class TrainingRecord {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Datum treninga. */
+    @NotNull
+    private LocalDate trainingDate;
+
+    /**
+     * Intenzitet (AVL) računat u servisu:
+     * Σ(sets × reps × weight × exercise.effort).
+     */
+    @DecimalMin("0.00")
+    private double intensity;
+
+    /** Trener koji je vodio trening (FK ka trainer). */
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "trainer_id")
+    private Trainer trainer;
+
+    /** Član koji je odradio trening (FK ka member). */
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}


### PR DESCRIPTION
Add initial JPA entities using Lombok and Bean Validation:
- ServicePackage, Exercise, Trainer, Member, TrainingRecord Each class includes short JavaDoc, field-level constraints, and proper table mapping.